### PR TITLE
Fix java link in the table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - [Driving](#driving)
 - [Community](#community)
 - [Repositories](#repositories)
-  - [Java](#javakotlin)
+  - [Java/Kotlin](#javakotlin)
   - [C++](#c)
   - [C#](#c-1)
   - [Python](#python)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - [Driving](#driving)
 - [Community](#community)
 - [Repositories](#repositories)
-  - [Java](#java)
+  - [Java](#javakotlin)
   - [C++](#c)
   - [C#](#c-1)
   - [Python](#python)


### PR DESCRIPTION
Fix the java link in the table of contents to link to javakotlin instead of just java. Also update the link to say Java/Kotlin.