### PR TITLE
Add LearnFRC — free structured learning site for every FRC department

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome FRC
+# Awesome FRC ✨
 
 A curated list of APIs, tools, and more. Useful for FRC teams.
 
@@ -9,7 +9,7 @@ Libraries
 Tools
 Websites
 
-## APIs
+## APIs 🖥️
 
 |                                  Name                                 |                                                 Description                                                |
 |:---------------------------------------------------------------------:|:----------------------------------------------------------------------------------------------------------:|
@@ -17,16 +17,16 @@ Websites
 |  [TheBlueAlliance API (v3)](https://www.thebluealliance.com/apidocs)  |  TheBlueAlliance offers event listings, team & match statistics, and results through their Developer API.  |
 | [Official FRC API](https://frc-events.firstinspires.org/services/API) |                      The official FRC API offers large amounts of team and match data.                     |
 
-## Libraries
+## Libraries 📚
 
 |                      Name                      |                                                    Description                                                    |
 |:----------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------:|
 | [WPILib Suite](https://github.com/wpilibsuite) | The official repositories of the WPILib Suite, a robotics software library used in the FIRST Robotics Competition |
 |      [RobotPy](https://github.com/robotpy)     |                            Unofficial pure Python implementations of the WPILib suite.                            |
 
-## Tools
+## Tools 🔧
 
-## Applications
+## Applications 📱
 
 |                       Name                       |                          Description                         |
 |:------------------------------------------------:|:------------------------------------------------------------:|

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A curated list of APIs, tools, and more. Useful for FRC teams.
 
-## Table of Contents
+## Table of Contents 📜
 
 APIs
 Libraries

--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ A curated list of APIs, tools, and more. Useful for FRC teams.
 | [FRC Spyder](https://play.google.com/store/apps/details?id=com.dwabtech.frcspyder&hl=en) | FRC Spyder gives you access to up-to-the-minute results for all FIRST Robotics Competition events of the 2019 season. |
 | [Robot Scouter](https://play.google.com/store/apps/details?id=com.supercilex.robotscouter&hl=en_CA) | Robot Scouter is an open-source Android app with three core goals: to make FIRST competition robot scouting easy, efficient, and collaborative. |
 | [TheBlueAlliance](https://play.google.com/store/apps/details?id=com.thebluealliance.androidclient&hl=en) | The Blue Alliance is the best way to scout, watch, and relive the FIRST Robotics Competition. |
+| [WPILib Libraries](https://wpilib.screenstepslive.com/s/currentCS/m/java/l/1035724-3rd-party-libraries) | A list of third party libraries that may need to be used by a team. |

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A curated list of APIs, tools, and more. Useful for FRC teams.
 
 ## Table of Contents 📜
 
-APIs
-Libraries
-Tools
-Websites
+[APIs](#APIs)
+[Libraries](#Libraries)
+[Tools](#Tools)
+[Websites](#Websites)
 
-## APIs 🖥️
+## <a name="APIs"></a> APIs 🖥️
 
 |                                  Name                                 |                                                 Description                                                |
 |:---------------------------------------------------------------------:|:----------------------------------------------------------------------------------------------------------:|
@@ -18,14 +18,14 @@ Websites
 | [Official FRC API](https://frc-events.firstinspires.org/services/API) |                      The official FRC API offers large amounts of team and match data.                     |
 
 
-## Libraries 📚
+## <a name="Libraries"></a> Libraries 📚
 
 |                      Name                      |                                                    Description                                                    |
 |:----------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------:|
 | [WPILib Suite](https://github.com/wpilibsuite) | The official repositories of the WPILib Suite, a robotics software library used in the FIRST Robotics Competition |
 |      [RobotPy](https://github.com/robotpy)     |                            Unofficial pure Python implementations of the WPILib suite.                            |
 
-## Applications 📱
+## <a name="Applications"></a> Applications 📱
 
 ### __NOTE:__ Mobile apps are only listed for Android. If you find an iOS equivalent, then make a PR :^)
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ A curated list of APIs, tools, and more. Useful for FRC teams.
 
 ## Table of Contents 📜
 
-[APIs](#APIs)
-[Libraries](#Libraries)
-[Tools](#Tools)
-[Websites](#Websites)
+- [APIs](#APIs)
+- [Libraries](#Libraries)
+- [Websites](#Websites)
 
 ## <a name="APIs"></a> APIs 🖥️
 

--- a/README.md
+++ b/README.md
@@ -31,3 +31,5 @@ Websites
 |                       Name                       |                          Description                         |
 |:------------------------------------------------:|:------------------------------------------------------------:|
 | [Pitmon](https://github.com/banting-7200/Pitmon) | See official rankings, statistics, and more all in your pit. |
+| [FRC Spyder](https://play.google.com/store/apps/details?id=com.dwabtech.frcspyder&hl=en) | FRC Spyder gives you access to up-to-the-minute results for all FIRST Robotics Competition events of the 2019 season. |
+| [Robot Scouter](https://play.google.com/store/apps/details?id=com.supercilex.robotscouter&hl=en_CA) | Robot Scouter is an open-source Android app with three core goals: to make FIRST competition robot scouting easy, efficient, and collaborative. |

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Websites
 
 ## APIs
 
-|         Name        |                                                 Description                                                |
-|:-------------------:|:----------------------------------------------------------------------------------------------------------:|
+|        Name         |                                                Description                                                 |
+| :-----------------: | :--------------------------------------------------------------------------------------------------------: |
 | FRC Events API (v2) | FMS FRC Events API is a service to return relevant information about the FIRST Robotics Competition (FRC). |
 |                     |                                                                                                            |
 |                     |                                                                                                            |

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Awesome FRC
+
+A curated list of APIs, tools, and more. Useful for FRC teams.
+
+## Table of Contents
+
+APIs
+Libraries
+Tools
+Websites
+
+## APIs
+
+### [FRC Events API](https://frcevents2.docs.apiary.io)
+
+FMS FRC Events API is a service to return relevant information about the FIRST Robotics Competition (FRC).
+
+## Libraries
+
+## Tools
+
+## Websites

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ Websites
 | [WPILib Suite](https://github.com/wpilibsuite) | The official repositories of the WPILib Suite, a robotics software library used in the FIRST Robotics Competition |
 |      [RobotPy](https://github.com/robotpy)     |                            Unofficial pure Python implementations of the WPILib suite.                            |
 
-## Tools 🔧
-
 ## Applications 📱
 
 |                       Name                       |                          Description                         |

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ Websites
 
 ## APIs
 
-|        Name         |                                                Description                                                 |
-| :-----------------: | :--------------------------------------------------------------------------------------------------------: |
-| FRC Events API (v2) | FMS FRC Events API is a service to return relevant information about the FIRST Robotics Competition (FRC). |
-|                     |                                                                                                            |
-|                     |                                                                                                            |
+|                                  Name                                 |                                                 Description                                                |
+|:---------------------------------------------------------------------:|:----------------------------------------------------------------------------------------------------------:|
+|       [FRC Events API (v2)](https://frcevents2.docs.apiary.io/)       | FMS FRC Events API is a service to return relevant information about the FIRST Robotics Competition (FRC). |
+|  [TheBlueAlliance API (v3)](https://www.thebluealliance.com/apidocs)  |  TheBlueAlliance offers event listings, team & match statistics, and results through their Developer API.  |
+| [Official FRC API](https://frc-events.firstinspires.org/services/API) |                      The official FRC API offers large amounts of team and match data.                     |
 
 ## Libraries
+
+
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Websites
 |  [TheBlueAlliance API (v3)](https://www.thebluealliance.com/apidocs)  |  TheBlueAlliance offers event listings, team & match statistics, and results through their Developer API.  |
 | [Official FRC API](https://frc-events.firstinspires.org/services/API) |                      The official FRC API offers large amounts of team and match data.                     |
 
+
 ## Libraries 📚
 
 |                      Name                      |                                                    Description                                                    |
@@ -26,8 +27,11 @@ Websites
 
 ## Applications 📱
 
+### __NOTE:__ Mobile apps are only listed for Android. If you find an iOS equivalent, then make a PR :^)
+
 |                       Name                       |                          Description                         |
 |:------------------------------------------------:|:------------------------------------------------------------:|
 | [Pitmon](https://github.com/banting-7200/Pitmon) | See official rankings, statistics, and more all in your pit. |
 | [FRC Spyder](https://play.google.com/store/apps/details?id=com.dwabtech.frcspyder&hl=en) | FRC Spyder gives you access to up-to-the-minute results for all FIRST Robotics Competition events of the 2019 season. |
 | [Robot Scouter](https://play.google.com/store/apps/details?id=com.supercilex.robotscouter&hl=en_CA) | Robot Scouter is an open-source Android app with three core goals: to make FIRST competition robot scouting easy, efficient, and collaborative. |
+| [TheBlueAlliance](https://play.google.com/store/apps/details?id=com.thebluealliance.androidclient&hl=en) | The Blue Alliance is the best way to scout, watch, and relive the FIRST Robotics Competition. |

--- a/README.md
+++ b/README.md
@@ -19,8 +19,15 @@ Websites
 
 ## Libraries
 
-
+|                      Name                      |                                                    Description                                                    |
+|:----------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------:|
+| [WPILib Suite](https://github.com/wpilibsuite) | The official repositories of the WPILib Suite, a robotics software library used in the FIRST Robotics Competition |
+|      [RobotPy](https://github.com/robotpy)     |                            Unofficial pure Python implementations of the WPILib suite.                            |
 
 ## Tools
 
-## Websites
+## Applications
+
+|                       Name                       |                          Description                         |
+|:------------------------------------------------:|:------------------------------------------------------------:|
+| [Pitmon](https://github.com/banting-7200/Pitmon) | See official rankings, statistics, and more all in your pit. |

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ Websites
 
 ## APIs
 
-### [FRC Events API](https://frcevents2.docs.apiary.io)
-
-FMS FRC Events API is a service to return relevant information about the FIRST Robotics Competition (FRC).
+|         Name        |                                                 Description                                                |
+|:-------------------:|:----------------------------------------------------------------------------------------------------------:|
+| FRC Events API (v2) | FMS FRC Events API is a service to return relevant information about the FIRST Robotics Competition (FRC). |
+|                     |                                                                                                            |
+|                     |                                                                                                            |
 
 ## Libraries
 


### PR DESCRIPTION
Adding [LearnFRC](https://learnfrc.systemerr.com/) to the General section.

Disclosure: I built it. It's a free, no-ads learning site for FRC students — structured guides with quizzes and printable certificates for all 11 team roles (programming, electrical, CAD, business, scouting, drive team, etc.), currently ~390 lessons. Used by students from 90+ teams so far. Feedback thread on Chief Delphi: https://www.chiefdelphi.com (LearnFRC resource thread).

Happy to adjust the wording or placement if you'd prefer.